### PR TITLE
fix: allow editar command in replies

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -332,6 +332,7 @@ async function handleTaggingMode(client, message, chatId) {
 function isValidCommand(messageBody) {
   const validCommands = [
     '#random',
+    '#editar',
     '#editar ID',
     '#top10',
     '#top5users',
@@ -355,6 +356,7 @@ function isValidCommand(messageBody) {
 async function handleInvalidCommand(client, chatId) {
   const validCommands = [
     '#random',
+    '#editar',
     '#editar ID',
     '#top10',
     '#top5users',

--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ function scheduleAutoSend(client) {
 }
 
 // ---- Comandos
-const VALID_COMMANDS = ['#random', '#editar ID', '#top10', '#top5users', '#ID', '#forçar', '#count'];
+const VALID_COMMANDS = ['#random', '#editar', '#editar ID', '#top10', '#top5users', '#ID', '#forçar', '#count'];
 
 function isValidCommand(body) {
   if (!body || !body.startsWith('#')) return false;


### PR DESCRIPTION
## Summary
- allow #editar replies to pass invalid-command filter by listing #editar as a valid command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a273638aa08332af8a6e4b28a477e7