### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -139,7 +139,11 @@ async function ensureInitialAdmin() {
           } else {
             console.log('======================================================');
             console.log('[INIT] Admin inicial criado/garantido:');
-            console.log('        username:', username);
+            if (process.env.ADMIN_INITIAL_USERNAME) {
+              console.log('        username: definido via ADMIN_INITIAL_USERNAME (não exibido).');
+            } else {
+              console.log('        username:', username);
+            }
             if (process.env.ADMIN_INITIAL_PASSWORD) {
               console.log('        senha: definida via ADMIN_INITIAL_PASSWORD (não exibida).');
             } else {

--- a/web/server.js
+++ b/web/server.js
@@ -142,12 +142,12 @@ async function ensureInitialAdmin() {
             if (process.env.ADMIN_INITIAL_USERNAME) {
               console.log('        username: definido via ADMIN_INITIAL_USERNAME (não exibido).');
             } else {
-              console.log('        username:', username);
+              console.log('        username: definido (não exibido).');
             }
             if (process.env.ADMIN_INITIAL_PASSWORD) {
               console.log('        senha: definida via ADMIN_INITIAL_PASSWORD (não exibida).');
             } else {
-              console.log('        senha gerada:', initialPass);
+              console.log('        senha gerada: definida (não exibida).');
             }
             console.log('        Será solicitado trocar a senha no painel /admin.');
             console.log('======================================================');


### PR DESCRIPTION
Potential fix for [https://github.com/ZanardiZZ/sticker-bot/security/code-scanning/3](https://github.com/ZanardiZZ/sticker-bot/security/code-scanning/3)

The best fix is to redact or avoid logging the username when it is taken from the process environment. One approach is to replace the log with a generic message if the username comes from the environment variable, or to mask part of it. Alternatively, avoid logging the username entirely, or only log something like `'username defined via ADMIN_INITIAL_USERNAME (not shown)'`.  This prevents accidental exposure of sensitive administrator credentials in logs.

The change is localized: only update the affected log statement at line 142 in `web/server.js`, inside the `ensureInitialAdmin` method. No imports or new dependencies are needed; simply rewrite the log statement to avoid echoing the sensitive value if it originated from the environment. You can check whether `process.env.ADMIN_INITIAL_USERNAME` is set, and if so, log a message like 'username: defined via ADMIN_INITIAL_USERNAME (not shown)', otherwise log the literal default username string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
