### PR TITLE
Fix theme match score aggregation in themed media query

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Send these commands to the bot in WhatsApp:
 | Command | Description | Example |
 |---------|-------------|---------|
 | `#random` | Get a random sticker | `#random` |
+| `#tema` | Send up to 10 stickers matching keywords | `#tema guerra 5` |
 | `#count` | Show total sticker count | `#count` |
 | `#top10` | Top 10 most used stickers | `#top10` |
 | `#top5users` | Top 5 users by sticker count | `#top5users` |

--- a/commands.js
+++ b/commands.js
@@ -18,6 +18,7 @@ const { handleTop5UsersCommand } = require('./commands/handlers/top5users');
 const { handleIdCommand } = require('./commands/handlers/id');
 const { handleForceCommand } = require('./commands/handlers/force');
 const { handleEditCommand } = require('./commands/handlers/edit');
+const { handleThemeCommand } = require('./commands/handlers/theme');
 const {
   saveMedia,
   getRandomMedia,
@@ -259,7 +260,8 @@ function isValidCommand(messageBody) {
     '#forçar',
     '#count',
     '#bot',
-    '#ping'
+    '#ping',
+    '#tema'
   ];
 
   if (!messageBody.startsWith('#')) return true; // não é comando
@@ -288,7 +290,8 @@ async function handleInvalidCommand(client, message, chatId) {
     '#forçar',
     '#count',
     '#bot',
-    '#ping'
+    '#ping',
+    '#tema'
   ];
 
   await safeReply(client, chatId,
@@ -392,6 +395,9 @@ async function handleCommand(client, message, chatId) {
           break;
         case '#editar':
           await handleEditCommand(client, message, chatId, taggingMap, MAX_TAGS_LENGTH);
+          break;
+        case '#tema':
+          await handleThemeCommand(client, message, chatId, params);
           break;
         case '#bot':
         case '#ping': {

--- a/commands/handlers/theme.js
+++ b/commands/handlers/theme.js
@@ -1,0 +1,108 @@
+/**
+ * Theme command handler - fetches media based on keywords
+ */
+
+const { findMediaByTheme, incrementRandomCount, getTagsForMedia } = require('../../database');
+const { sendMediaByType } = require('../media');
+const { renderInfoMessage } = require('../../utils/messageUtils');
+const { safeReply } = require('../../utils/safeMessaging');
+
+/**
+ * Parses command parameters to extract keywords and limit
+ * @param {string[]} params - Array of command parameters
+ * @returns {{ keywords: string[], limit: number }} Parsed keywords and limit
+ */
+function parseThemeParams(params = []) {
+  const workingParams = Array.isArray(params) ? [...params] : [];
+
+  if (!workingParams.length) {
+    return { keywords: [], limit: 1 };
+  }
+
+  let limit = 1;
+  const lastParam = workingParams[workingParams.length - 1];
+
+  if (/^\d+$/.test(lastParam)) {
+    limit = Math.min(10, Math.max(1, parseInt(lastParam, 10)));
+    workingParams.pop();
+  }
+
+  const keywords = workingParams
+    .map(param => (typeof param === 'string' ? param.trim() : ''))
+    .filter(Boolean);
+
+  return { keywords, limit };
+}
+
+/**
+ * Handles the #tema command
+ * @param {object} client - WhatsApp client
+ * @param {object} message - Message object
+ * @param {string} chatId - Chat ID
+ * @param {string[]} params - Command parameters
+ */
+async function handleThemeCommand(client, message, chatId, params = []) {
+  try {
+    const { keywords, limit } = parseThemeParams(params);
+
+    if (!keywords.length) {
+      await safeReply(
+        client,
+        chatId,
+        'Uso: #tema <palavras-chave> <quantidade (1-10)>\nExemplo: #tema guerra 5',
+        message.id
+      );
+      return;
+    }
+
+    const mediaList = await findMediaByTheme(keywords, limit);
+
+    if (!mediaList.length) {
+      await safeReply(
+        client,
+        chatId,
+        `Não encontrei figurinhas para o tema "${keywords.join(' ')}".`,
+        message.id
+      );
+      return;
+    }
+
+    const requestedCount = limit;
+    const deliveredCount = mediaList.length;
+
+    const mediaWithDetails = await Promise.all(
+      mediaList.map(async media => {
+        const [, tags] = await Promise.all([
+          incrementRandomCount(media.id),
+          getTagsForMedia(media.id)
+        ]);
+
+        return { media, tags };
+      })
+    );
+
+    for (const { media, tags } of mediaWithDetails) {
+      await sendMediaByType(client, chatId, media);
+
+      const infoText = renderInfoMessage(media, tags);
+
+      if (infoText.trim()) {
+        await safeReply(client, chatId, infoText, message.id);
+      }
+    }
+
+    if (deliveredCount < requestedCount) {
+      await safeReply(
+        client,
+        chatId,
+        `Foram encontradas apenas ${deliveredCount} figurinhas para o tema solicitado.`,
+        message.id
+      );
+    }
+  } catch (err) {
+    console.error('Erro no comando #tema:', err);
+    await safeReply(client, chatId, 'Erro ao buscar figurinhas por tema.', message.id);
+  }
+}
+
+module.exports = { handleThemeCommand };

--- a/commands/index.js
+++ b/commands/index.js
@@ -10,6 +10,7 @@ const { handleTop5UsersCommand } = require('./handlers/top5users');
 const { handleIdCommand } = require('./handlers/id');
 const { handleForceCommand } = require('./handlers/force');
 const { handleEditCommand } = require('./handlers/edit');
+const { handleThemeCommand } = require('./handlers/theme');
 
 // Utilities
 const validation = require('./validation');
@@ -24,6 +25,7 @@ module.exports = {
   handleIdCommand,
   handleForceCommand,
   handleEditCommand,
+  handleThemeCommand,
   
   // Utilities
   ...validation,

--- a/commands/validation.js
+++ b/commands/validation.js
@@ -15,7 +15,8 @@ const VALID_COMMANDS = [
   '#top5users',
   '#ID',
   '#forçar',
-  '#count'
+  '#count',
+  '#tema'
 ];
 
 /**

--- a/database/models/media.js
+++ b/database/models/media.js
@@ -177,6 +177,71 @@ function getTop10Media() {
   });
 }
 
+/**
+ * Finds media items that match provided keywords in description or tags
+ * @param {string[]} keywords - Array of keyword strings
+ * @param {number} limit - Maximum number of media items to return
+ * @returns {Promise<object[]>} Array of matching media objects ordered by relevance
+ */
+function findMediaByTheme(keywords, limit = 5) {
+  return new Promise((resolve) => {
+    if (!Array.isArray(keywords) || keywords.length === 0) {
+      resolve([]);
+      return;
+    }
+
+    const cleanKeywords = keywords
+      .map(keyword => (typeof keyword === 'string' ? keyword.trim().toLowerCase() : ''))
+      .filter(Boolean);
+
+    if (!cleanKeywords.length) {
+      resolve([]);
+      return;
+    }
+
+    const matchExpressions = cleanKeywords.map(() => `MAX(
+      CASE
+        WHEN LOWER(COALESCE(m.description, '')) LIKE ?
+          OR LOWER(COALESCE(t.name, '')) LIKE ?
+        THEN 1 ELSE 0
+      END
+    )`);
+
+    const matchScoreExpression = matchExpressions.join(' + ');
+
+    const sql = `
+      SELECT m.*, ${matchScoreExpression} AS match_score
+      FROM media m
+      LEFT JOIN media_tags mt ON m.id = mt.media_id
+      LEFT JOIN tags t ON t.id = mt.tag_id
+      WHERE m.nsfw = 0
+      GROUP BY m.id
+      HAVING match_score > 0
+      ORDER BY m.count_random ASC, match_score DESC, m.id ASC
+      LIMIT ?
+    `;
+
+    const params = [];
+    cleanKeywords.forEach(keyword => {
+      const pattern = `%${keyword}%`;
+      params.push(pattern, pattern);
+    });
+
+    const normalizedLimit = Number.isInteger(limit) ? limit : parseInt(limit, 10);
+    const parsedLimit = Number.isNaN(normalizedLimit) ? 5 : Math.max(1, normalizedLimit);
+    params.push(parsedLimit);
+
+    db.all(sql, params, (err, rows) => {
+      if (err) {
+        console.error('[DB] Erro ao buscar mídia por tema:', err);
+        resolve([]);
+      } else {
+        resolve(rows || []);
+      }
+    });
+  });
+}
+
 module.exports = {
   saveMedia,
   findByHashVisual,
@@ -186,5 +251,6 @@ module.exports = {
   incrementRandomCount,
   updateMediaDescription,
   countMedia,
-  getTop10Media
+  getTop10Media,
+  findMediaByTheme
 };


### PR DESCRIPTION
## Summary
- aggregate each themed keyword match with MAX so match scores consider all joined tag rows

## Testing
- npm run test:unit *(fails: known ID command assertions still failing in suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dc85f76af88332ad8db68abb52f9ab