### PR TITLE
Fix duplicate SSE close listener cleanup

### DIFF
--- a/web/routes/admin.js
+++ b/web/routes/admin.js
@@ -241,19 +241,15 @@ function createAdminRoutes(db) {
     // Verificar por novos logs a cada 2 segundos
     const interval = setInterval(checkForNewLogs, 2000);
 
-    // Limpar quando o cliente desconectar
-    req.on('close', () => {
-      clearInterval(interval);
-      console.log('[SSE] Cliente de logs desconectado');
-    });
-
     // Keep-alive ping
     const pingInterval = setInterval(() => {
       res.write(': ping\n\n');
     }, 30000);
 
     req.on('close', () => {
+      clearInterval(interval);
       clearInterval(pingInterval);
+      console.log('[SSE] Cliente de logs desconectado');
     });
   });
 


### PR DESCRIPTION
## Summary
- consolidate the admin log stream SSE close handler to avoid duplicate listener registration
- ensure both log polling and ping intervals are cleared when the client disconnects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2fac126c8332be4cd314963cc918