### PR TITLE
Add folder guidelines for key directories

### DIFF
--- a/commands/AGENTS.md
+++ b/commands/AGENTS.md
@@ -1,0 +1,7 @@
+# Diretrizes para `commands`
+
+- Utilize módulos CommonJS (`require`/`module.exports`) e mantenha a estrutura de exportação centralizada em `commands/index.js`.
+- Cada handler novo deve ser uma função assíncrona documentada com JSDoc e envolver chamadas I/O em blocos `try/catch`, retornando mensagens de erro em português para o usuário final.
+- Use somente helpers expostos em `../utils` e `../database` para acessar funcionalidades compartilhadas; evite instanciar clientes externos diretamente dentro dos comandos.
+- Validações de entrada pertencem a `validation.js` ou a novos utilitários análogos; mantenha a lógica de negócios dos handlers enxuta e delegue operações a serviços/DB.
+- Ao adicionar um comando, atualize também os testes correspondentes em `tests/` e garanta que o comando não bloqueie o event loop (sem loops síncronos longos).

--- a/database/AGENTS.md
+++ b/database/AGENTS.md
@@ -1,0 +1,8 @@
+# Diretrizes para `database`
+
+- Este diretório concentra a camada de dados (SQLite). Novas consultas devem ser implementadas como funções em `index.js` ou em submódulos especializados, sempre exportando interfaces claras.
+- Utilize `db.serialize`/`db.run`/`db.all` com parâmetros (`?`) para evitar injeção de SQL. Nunca concatene valores diretamente em strings SQL.
+- Alterações de esquema precisam ser refletidas em migrações dentro de `database/migrations`; documente passos manuais quando necessário.
+- Funções de acesso ao banco devem retornar `Promise` e lidar com erros rejeitando com objetos `Error` contextualizados; não silencie exceções.
+- Logue operações críticas com prefixos `[DB]` apenas quando indispensável e mantenha mensagens em português.
+- Ao adicionar índices/tabelas novas, atualize a documentação pertinente e inclua testes que cubram consultas e migrações em `tests/database`.

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -1,0 +1,8 @@
+# Diretrizes para `services`
+
+- Serviços encapsulam integrações externas (IA, fila de mídia, filtros). Estruture módulos como funções ou classes que recebam dependências por parâmetro para facilitar testes.
+- Utilize CommonJS e documente APIs públicas com JSDoc. Exporte apenas a superfície necessária para outros módulos.
+- Evite guardar estado global persistente; se necessário, proteja com estruturas resilientes e exponha métodos de inicialização/encerramento explícitos.
+- Acesso a banco deve ocorrer via `../database` utilizando consultas parametrizadas; nunca monte SQL com interpolação direta.
+- Prefira logging com prefixos (`[SERVICE:<nome>]`) e trate exceções propagando erros significativos para quem consome o serviço.
+- Adicione ou atualize testes em `tests/services` para cobrir fluxos principais e use mocks para dependências externas pesadas.

--- a/utils/AGENTS.md
+++ b/utils/AGENTS.md
@@ -1,0 +1,7 @@
+# Diretrizes para `utils`
+
+- Os utilitários devem ser funções puras ou side-effect free sempre que possível; quando não for viável, injete dependências (ex.: cliente WhatsApp) via parâmetros.
+- Mantenha a compatibilidade com CommonJS e documente funções públicas com JSDoc descrevendo parâmetros e retornos.
+- Padronize mensagens e logs em português e utilize `utils/logCollector` para capturar logs extensos; evite `console.log` disperso.
+- Não acople utilitários diretamente a bibliotecas web ou serviços; qualquer integração específica deve viver em `services/` ou `web/` e consumir utilitários via importação.
+- Antes de introduzir novas dependências, verifique se já existe utilitário equivalente; adicione/atualize testes unitários em `tests/` quando alterar comportamento.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,8 @@
+# Diretrizes para `web`
+
+- Este diretório hospeda o painel Express. Mantenha rotas, middlewares e serviços separados em subpastas e siga o padrão CommonJS.
+- Toda rota nova deve exigir autenticação adequada (`requireLogin`/`requireAdmin`) e validar entrada antes de usar recursos sensíveis.
+- Use `async/await` com tratamento de erros centralizado; registre falhas via `utils/logCollector` ou `console` com prefixos claros (ex.: `[WEB]`).
+- Parâmetros de configuração devem vir de `process.env` com valores padrão seguros; nunca faça require direto de arquivos `.env` fora de `server.js`.
+- Evite lógica de negócio pesada nas rotas: delegue para `services/` ou `database/`. Adicione testes de integração ou unitários relevantes em `tests/web` ao modificar comportamento crítico.
+- Recursos estáticos devem residir em `web/public`; mantenha dependências front-end mínimas e documente instruções de build quando necessário.


### PR DESCRIPTION
## Summary
- add Portuguese AGENTS instructions for the commands, utils, web, services, and database directories
- document expectations around CommonJS usage, error handling, logging, and testing per folder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3102066883329a25a56a57ee65d7