### PR TITLE
feat: expand baileys adapter interoperability

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1,4 +1,3 @@
-const { decryptMedia } = require('@open-wa/wa-decrypt');
 const path = require('path');
 const sharp = require('sharp');
 const { PACK_NAME, AUTHOR_NAME } = require('./config/stickers');

--- a/commands/handlers/edit.js
+++ b/commands/handlers/edit.js
@@ -2,7 +2,7 @@
  * Edit command handler
  */
 
-const { decryptMedia } = require('@open-wa/wa-decrypt');
+const { downloadMediaForMessage } = require('../../utils/mediaDownload');
 const { getHashVisual, findByHashVisual } = require('../../database');
 const { normalizeText, parseCommand } = require('../../utils/commandNormalizer');
 const { safeReply } = require('../../utils/safeMessaging');
@@ -20,13 +20,13 @@ async function handleEditReply(client, message, chatId, taggingMap, MAX_TAGS_LEN
   try {
     const quoted = await client.getQuotedMessage(message.id);
     if (quoted.isMedia) {
-      const buf = await decryptMedia(quoted);
-      const hv = await getHashVisual(buf);
+      const { buffer } = await downloadMediaForMessage(client, quoted);
+      const hv = await getHashVisual(buffer);
       const rec = await findByHashVisual(hv);
       if (rec) {
         taggingMap.set(chatId, rec.id);
         await safeReply(
-          chatId,
+          client,
           `Modo edição ativado para a mídia ID ${rec.id}.\n\n` +
             'Envie no formato:\n' +
             'descricao: [sua descrição]; tags: tag1, tag2, tag3\n' +

--- a/server.js
+++ b/server.js
@@ -53,43 +53,195 @@ function isTokenAllowed(token) {
   return ALLOWED_TOKENS.includes(token);
 }
 
-function normalizeOpenWAMessage(msg) {
+function normalizeOpenWAMessage(msg, opts = {}) {
+  const { store, userId, rememberMessage, rememberQuoted } = opts;
+
   // Convert Baileys message to an OpenWA-like shape used by current code
   const m = msg?.messages?.[0];
   if (!m) return null;
+
   const remoteJid = m.key?.remoteJid || '';
-  const from = remoteJid;
-  const isGroupMsg = String(remoteJid).endsWith('@g.us');
   const chatId = remoteJid;
   const id = m.key?.id;
-  const senderId = m.key?.participant || m.participant || m.pushName || m.key?.fromMe ? undefined : undefined;
+  const fromMe = !!m.key?.fromMe;
 
-  // Body extraction (text/caption)
-  let body = '';
-  try {
-    body = m.message?.conversation
+  const isGroupMsg = String(remoteJid).endsWith('@g.us');
+
+  const unwrapMessageContent = (message) => {
+    if (!message) return { type: null, content: null };
+    if (message.viewOnceMessage?.message) return unwrapMessageContent(message.viewOnceMessage.message);
+    if (message.viewOnceMessageV2?.message) return unwrapMessageContent(message.viewOnceMessageV2.message);
+    if (message.viewOnceMessageV2Extension?.message) return unwrapMessageContent(message.viewOnceMessageV2Extension.message);
+    const entries = Object.entries(message).filter(([, value]) => value);
+    if (!entries.length) return { type: null, content: null };
+    const [type, content] = entries[0];
+    return { type, content };
+  };
+
+  const getFromStore = (collection, key) => {
+    if (!collection || !key) return null;
+    const altKey = typeof key === 'string' && key.endsWith('@s.whatsapp.net')
+      ? key.replace('@s.whatsapp.net', '@c.us')
+      : null;
+    if (typeof collection.get === 'function') {
+      return collection.get(key) || (altKey ? collection.get(altKey) : null) || null;
+    }
+    if (Object.prototype.hasOwnProperty.call(collection, key)) return collection[key];
+    if (altKey && Object.prototype.hasOwnProperty.call(collection, altKey)) return collection[altKey];
+    return null;
+  };
+
+  const getContactFromStore = (jid) => {
+    if (!jid) return null;
+    return getFromStore(store?.contacts, jid);
+  };
+
+  const getChatFromStore = (jid) => {
+    if (!jid) return null;
+    return getFromStore(store?.chats, jid) || getFromStore(store?.groupMetadata, jid);
+  };
+
+  const unwrap = unwrapMessageContent(m.message || {});
+  const content = unwrap.content || {};
+  const messageType = unwrap.type || '';
+  const contextInfo = content.contextInfo
+    || m.message?.extendedTextMessage?.contextInfo
+    || m.message?.imageMessage?.contextInfo
+    || m.message?.videoMessage?.contextInfo
+    || m.message?.documentMessage?.contextInfo
+    || m.message?.audioMessage?.contextInfo
+    || null;
+
+  const extractBody = () => {
+    return (
+      content?.text
+      || content?.caption
+      || m.message?.conversation
       || m.message?.extendedTextMessage?.text
       || m.message?.imageMessage?.caption
       || m.message?.videoMessage?.caption
-      || '';
-  } catch {}
+      || ''
+    );
+  };
 
-  // Media detection
+  const body = extractBody();
+
   let isMedia = false;
   let mimetype = '';
   let type = 'chat';
-  if (m.message?.imageMessage) {
-    isMedia = true; mimetype = m.message.imageMessage.mimetype || 'image/jpeg'; type = 'image';
-  } else if (m.message?.videoMessage) {
-    isMedia = true; mimetype = m.message.videoMessage.mimetype || 'video/mp4'; type = 'video';
-  } else if (m.message?.stickerMessage) {
-    isMedia = true; mimetype = m.message.stickerMessage.mimetype || 'image/webp'; type = 'sticker';
-  } else if (m.message?.audioMessage) {
-    isMedia = true; mimetype = m.message.audioMessage.mimetype || 'audio/ogg'; type = 'audio';
+  if (messageType === 'imageMessage') {
+    isMedia = true; mimetype = content.mimetype || 'image/jpeg'; type = 'image';
+  } else if (messageType === 'videoMessage') {
+    isMedia = true; mimetype = content.mimetype || 'video/mp4'; type = 'video';
+  } else if (messageType === 'stickerMessage') {
+    isMedia = true; mimetype = content.mimetype || 'image/webp'; type = 'sticker';
+  } else if (messageType === 'audioMessage') {
+    isMedia = true; mimetype = content.mimetype || 'audio/ogg'; type = 'audio';
+  } else if (messageType === 'documentMessage') {
+    isMedia = true; mimetype = content.mimetype || 'application/octet-stream'; type = 'document';
   }
 
-  return {
-    from,
+  const senderId = fromMe
+    ? (userId || remoteJid)
+    : (m.key?.participant || m.participant || remoteJid);
+  const senderContact = getContactFromStore(senderId);
+  const senderPushname = m.pushName
+    || senderContact?.pushName
+    || senderContact?.name
+    || senderContact?.verifiedName
+    || senderContact?.notify
+    || '';
+
+  const sender = {
+    id: senderId || '',
+    pushname: senderPushname,
+    formattedName: senderContact?.name || senderContact?.verifiedName || senderPushname || '',
+    notifyName: senderContact?.notify || '',
+    name: senderContact?.name || senderPushname || ''
+  };
+
+  const chatMeta = getChatFromStore(chatId);
+  const chat = {
+    id: chatId,
+    name: chatMeta?.name || chatMeta?.subject || chatMeta?.formattedTitle || '',
+    formattedTitle: chatMeta?.formattedTitle || chatMeta?.subject || chatMeta?.name || ''
+  };
+
+  let quotedMsg = null;
+  let quotedMsgId = null;
+  if (contextInfo?.quotedMessage) {
+    const qUnwrap = unwrapMessageContent(contextInfo.quotedMessage);
+    const qContent = qUnwrap.content || {};
+    const qTypeRaw = qUnwrap.type || '';
+
+    let qType = 'chat';
+    let qBody = (
+      qContent?.text
+      || qContent?.caption
+      || contextInfo.quotedMessage?.conversation
+      || ''
+    );
+    let qIsMedia = false;
+    let qMimetype = '';
+
+    if (qTypeRaw === 'imageMessage') {
+      qType = 'image'; qIsMedia = true; qMimetype = qContent.mimetype || 'image/jpeg';
+      if (!qBody) qBody = qContent?.caption || '';
+    } else if (qTypeRaw === 'videoMessage') {
+      qType = 'video'; qIsMedia = true; qMimetype = qContent.mimetype || 'video/mp4';
+      if (!qBody) qBody = qContent?.caption || '';
+    } else if (qTypeRaw === 'stickerMessage') {
+      qType = 'sticker'; qIsMedia = true; qMimetype = qContent.mimetype || 'image/webp';
+    } else if (qTypeRaw === 'audioMessage') {
+      qType = 'audio'; qIsMedia = true; qMimetype = qContent.mimetype || 'audio/ogg';
+    } else if (qTypeRaw === 'documentMessage') {
+      qType = 'document'; qIsMedia = true; qMimetype = qContent.mimetype || 'application/octet-stream';
+    }
+
+    const qId = contextInfo.stanzaId || contextInfo.stanzaID || contextInfo.messageId || null;
+    const qParticipant = contextInfo.participant || contextInfo.remoteJid || contextInfo.quotedParticipant || null;
+    const qSenderId = qParticipant || chatId;
+    const qContact = getContactFromStore(qSenderId);
+    const qPushname = qContact?.pushName || qContact?.name || qContact?.verifiedName || qContact?.notify || '';
+
+    quotedMsgId = qId;
+    quotedMsg = {
+      id: qId || '',
+      chatId,
+      from: qSenderId,
+      messageId: qId || '',
+      body: qBody || '',
+      type: qType,
+      isMedia: qIsMedia,
+      mimetype: qMimetype,
+      sender: {
+        id: qSenderId || '',
+        pushname: qPushname,
+        formattedName: qContact?.name || qContact?.verifiedName || qPushname || '',
+        notifyName: qContact?.notify || '',
+        name: qContact?.name || qPushname || ''
+      },
+      author: qSenderId || '',
+      isGroupMsg: isGroupMsg,
+      _fromQuote: true
+    };
+
+    if (quotedMsg && typeof rememberQuoted === 'function') {
+      const rawMessage = {
+        key: {
+          id: qId,
+          remoteJid: chatId,
+          fromMe: qSenderId ? qSenderId === userId : false,
+          participant: qSenderId || undefined
+        },
+        message: contextInfo.quotedMessage
+      };
+      rememberQuoted(quotedMsg, rawMessage);
+    }
+  }
+
+  const normalized = {
+    from: remoteJid,
     chatId,
     id,
     messageId: id,
@@ -98,11 +250,23 @@ function normalizeOpenWAMessage(msg) {
     isMedia,
     mimetype,
     isGroupMsg,
-    sender: { id: m.key?.participant || m.pushName || '' },
-    author: m.key?.participant || '',
+    sender,
+    chat,
+    author: m.key?.participant || sender.id || '',
+    hasQuotedMsg: !!quotedMsg,
+    quotedMsgId: quotedMsgId || null,
+    quotedMsg: quotedMsg || null,
+    timestamp: Number(m.messageTimestamp) || Date.now() / 1000,
+    fromMe,
     // raw for advanced usage
     _raw: m
   };
+
+  if (typeof rememberMessage === 'function') {
+    rememberMessage(normalized, m);
+  }
+
+  return normalized;
 }
 
 async function start() {
@@ -155,6 +319,8 @@ async function start() {
   // cache limited number of recent media messages for download on demand
   const MAX_CACHE = 500;
   const mediaCache = new Map(); // messageId -> { m, chatId }
+  const MAX_MESSAGE_CACHE = 1000;
+  const messageCache = new Map(); // messageId -> { normalized, raw }
 
   function rememberMedia(m) {
     try {
@@ -167,6 +333,70 @@ async function start() {
       }
       mediaCache.set(id, { m, chatId });
     } catch {}
+  }
+
+  function rememberMessage(normalized, raw) {
+    try {
+      const messageId = normalized?.id || normalized?.messageId || raw?.key?.id;
+      if (!messageId) return;
+      if (messageCache.size >= MAX_MESSAGE_CACHE) {
+        const firstKey = messageCache.keys().next().value;
+        if (firstKey) messageCache.delete(firstKey);
+      }
+      messageCache.set(messageId, {
+        normalized: { ...normalized },
+        raw
+      });
+    } catch {}
+  }
+
+  function rememberQuoted(normalized, raw) {
+    rememberMessage(normalized, raw);
+    try {
+      if (
+        raw?.message?.imageMessage
+        || raw?.message?.videoMessage
+        || raw?.message?.stickerMessage
+        || raw?.message?.audioMessage
+        || raw?.message?.documentMessage
+      ) {
+        rememberMedia(raw);
+      }
+    } catch {}
+  }
+
+  function buildContactPayload(jid) {
+    if (!jid) {
+      return { id: '', pushname: '', formattedName: '', notifyName: '', name: '', number: '' };
+    }
+
+    const resolveFromStore = (collection) => {
+      if (!collection) return null;
+      const altJid = jid.endsWith('@s.whatsapp.net') ? jid.replace('@s.whatsapp.net', '@c.us') : null;
+      if (typeof collection.get === 'function') {
+        return collection.get(jid) || (altJid ? collection.get(altJid) : null) || null;
+      }
+      if (Object.prototype.hasOwnProperty.call(collection, jid)) return collection[jid];
+      if (altJid && Object.prototype.hasOwnProperty.call(collection, altJid)) return collection[altJid];
+      return null;
+    };
+
+    const contact = resolveFromStore(store?.contacts) || null;
+    const pushname = contact?.pushName || contact?.name || contact?.verifiedName || contact?.notify || '';
+
+    return {
+      id: jid,
+      pushname,
+      formattedName: contact?.name || contact?.verifiedName || pushname || '',
+      notifyName: contact?.notify || '',
+      name: contact?.name || pushname || '',
+      shortName: contact?.shortName || '',
+      verifiedName: contact?.verifiedName || '',
+      isBusiness: !!contact?.isBusiness,
+      isEnterprise: !!contact?.isEnterprise,
+      profilePicUrl: contact?.profilePictureUrl || contact?.profilePicUrl || '',
+      number: jid.split('@')[0] || '',
+    };
   }
 
   function broadcastAuthorized(openwaMsg) {
@@ -345,18 +575,53 @@ async function start() {
       if (type === 'downloadMedia') {
         const { messageId } = msg || {};
         const cached = messageId ? mediaCache.get(messageId) : null;
-        if (!cached) return send(ws, { type: 'error', error: 'media_not_found' });
+        if (!cached) return send(ws, { type: 'error', action: 'downloadMedia', messageId, error: 'media_not_found' });
         const { m, chatId } = cached;
         const entryCan = entry.allowedChats.has('*') || entry.allowedChats.has(chatId);
-        if (!entryCan) return send(ws, { type: 'error', error: 'forbidden' });
+        if (!entryCan) return send(ws, { type: 'error', action: 'downloadMedia', messageId, error: 'forbidden' });
         try {
           const buf = await buildMediaBuffer(m);
           const mimetype = m.message?.imageMessage?.mimetype || m.message?.videoMessage?.mimetype || m.message?.stickerMessage?.mimetype || m.message?.audioMessage?.mimetype || m.message?.documentMessage?.mimetype || 'application/octet-stream';
           const dataUrl = `data:${mimetype};base64,${buf.toString('base64')}`;
           return send(ws, { type: 'media', messageId, mimetype, dataUrl });
         } catch (e) {
-          return send(ws, { type: 'error', error: e.message || String(e) });
+          return send(ws, { type: 'error', action: 'downloadMedia', messageId, error: e.message || String(e) });
         }
+      }
+
+      if (type === 'getQuotedMessage') {
+        const { messageId } = msg || {};
+        if (!messageId) return send(ws, { type: 'error', action: 'getQuotedMessage', error: 'messageId_required' });
+        const stored = messageCache.get(messageId);
+        if (!stored) return send(ws, { type: 'error', action: 'getQuotedMessage', messageId, error: 'quoted_not_found' });
+
+        let target = null;
+        if (stored.normalized?._fromQuote) {
+          target = stored.normalized;
+        } else if (stored.normalized?.quotedMsg) {
+          target = stored.normalized.quotedMsg;
+        } else if (stored.normalized?.quotedMsgId) {
+          const nested = messageCache.get(stored.normalized.quotedMsgId);
+          if (nested?.normalized) target = nested.normalized;
+        }
+
+        if (!target) {
+          return send(ws, { type: 'error', action: 'getQuotedMessage', messageId, error: 'quoted_not_found' });
+        }
+
+        const chatId = target.chatId || stored.normalized?.chatId;
+        if (chatId && !canSendTo(chatId)) {
+          return send(ws, { type: 'error', action: 'getQuotedMessage', messageId, error: 'forbidden' });
+        }
+
+        return send(ws, { type: 'quotedMessage', messageId, data: target });
+      }
+
+      if (type === 'getContact') {
+        const { jid } = msg || {};
+        if (!jid) return send(ws, { type: 'error', action: 'getContact', error: 'jid_required' });
+        const contactPayload = buildContactPayload(jid);
+        return send(ws, { type: 'contact', jid, data: contactPayload });
       }
     });
 
@@ -375,7 +640,12 @@ async function start() {
   // Forwarding incoming messages to authorized clients
   sock.ev.on('messages.upsert', (evt) => {
     if (!evt?.messages) return;
-    const wrapped = normalizeOpenWAMessage(evt);
+    const wrapped = normalizeOpenWAMessage(evt, {
+      store,
+      userId: sock?.user?.id,
+      rememberMessage,
+      rememberQuoted
+    });
     if (wrapped) {
       // remember media for later download
       const m = evt.messages?.[0];

--- a/utils/mediaDownload.js
+++ b/utils/mediaDownload.js
@@ -1,0 +1,38 @@
+const { decryptMedia } = require('@open-wa/wa-decrypt');
+
+/**
+ * Downloads media for a WhatsApp message, preferring the Baileys adapter RPC when available.
+ * Falls back to the legacy decryptMedia implementation for open-wa clients.
+ *
+ * @param {Object} client - WhatsApp client or adapter instance
+ * @param {Object} message - Message payload containing the media metadata
+ * @returns {Promise<{ buffer: Buffer, mimetype: string }>} Media buffer and mimetype
+ */
+async function downloadMediaForMessage(client, message) {
+  if (!message) {
+    throw new Error('message_required');
+  }
+
+  const messageId = message?.id || message?.messageId || message?.key?.id;
+
+  if (client && typeof client.getMediaBuffer === 'function') {
+    if (!messageId) {
+      throw new Error('message_id_missing');
+    }
+    const { buffer, mimetype } = await client.getMediaBuffer(messageId);
+    return {
+      buffer,
+      mimetype: mimetype || message?.mimetype || 'application/octet-stream'
+    };
+  }
+
+  const buffer = await decryptMedia(message);
+  return {
+    buffer,
+    mimetype: message?.mimetype || 'application/octet-stream'
+  };
+}
+
+module.exports = {
+  downloadMediaForMessage,
+};


### PR DESCRIPTION
## Summary
- enrich the Baileys message normalizer with quoted-message metadata, caching and RPC support for fetching quotes and contacts
- add a shared media download helper that prefers the Baileys adapter pipeline and update media/edit handlers to use it
- expose getQuotedMessage/getContact on the WebSocket adapter and propagate contact details to downstream consumers

## Testing
- npm run test:unit *(fails: missing sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68dd304fa5b483329575c0e341738e91