### PR TITLE
Potential fix for code scanning alert no. 16: Use of externally-controlled format string

### DIFF
--- a/web/public/admin.js
+++ b/web/public/admin.js
@@ -837,7 +837,7 @@ function setActiveSubTab(tabId, options = {}) {
   if (!initializedSubTabs.has(tabId) && typeof subTabLoaders[tabId] === 'function') {
     initializedSubTabs.add(tabId);
     Promise.resolve(subTabLoaders[tabId]()).catch((error) => {
-      console.warn(`Failed to initialize sub-tab "${tabId}":`, error);
+      console.warn('Failed to initialize sub-tab "%s":', tabId, error);
     });
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ZanardiZZ/sticker-bot/security/code-scanning/16](https://github.com/ZanardiZZ/sticker-bot/security/code-scanning/16)

To fix the issue, we should avoid embedding the untrusted `tabId` directly into the template string that is passed as the first argument to `console.warn`, because even though most JS engines will not treat the template string as a format string, it is best practice to pass untrusted data as a separate argument to avoid any misinterpretation by any JS engine or console implementation. 

**The best way to fix this is:**
- Change the log statement at line 840 from:
  ```js
  console.warn(`Failed to initialize sub-tab "${tabId}":`, error);
  ```
  to:
  ```js
  console.warn('Failed to initialize sub-tab "%s":', tabId, error);
  ```
- This uses a fixed format string with a `%s` placeholder, and provides `tabId` as a separate argument.  
- No new imports or utility methods are needed, as this is standard usage for `console.warn`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
