### PR TITLE
refactor: share sender admin metadata helper

### DIFF
--- a/commands/handlers/ban.js
+++ b/commands/handlers/ban.js
@@ -6,7 +6,7 @@
 const { safeReply } = require('../../utils/safeMessaging');
 const { normalizeJid, isJidGroup } = require('../../utils/jidUtils');
 const { resolveSenderId } = require('../../database');
-const { getEnvAdminSet } = require('../../utils/adminUtils');
+const { getEnvAdminSet, senderIsAdminFromMessage } = require('../../utils/adminUtils');
 
 /**
  * Extract mentioned JID from message
@@ -49,22 +49,7 @@ function isAdmin(resolvedSenderId, message) {
     return true;
   }
 
-  // Check message sender metadata
-  const sender = message?.sender;
-  if (!sender) return false;
-  
-  if (sender.isAdmin === true || sender.isSuperAdmin === true) return true;
-  
-  if (typeof sender.admin === 'string') {
-    const lowered = sender.admin.toLowerCase();
-    if (lowered.includes('admin')) return true;
-  }
-  
-  if (Array.isArray(sender.labels)) {
-    return sender.labels.some(label => typeof label === 'string' && label.toLowerCase().includes('admin'));
-  }
-  
-  return false;
+  return senderIsAdminFromMessage(message);
 }
 
 /**

--- a/commands/handlers/delete.js
+++ b/commands/handlers/delete.js
@@ -1,7 +1,7 @@
 const { safeReply } = require('../../utils/safeMessaging');
 const { parseCommand } = require('../../utils/commandNormalizer');
 const { normalizeJid, isJidGroup } = require('../../utils/jidUtils');
-const { getEnvAdminSet } = require('../../utils/adminUtils');
+const { getEnvAdminSet, senderIsAdminFromMessage } = require('../../utils/adminUtils');
 const {
   findById,
   deleteMediaByIds,
@@ -59,20 +59,6 @@ async function loadVoteThreshold() {
 function invalidateVoteThresholdCache() {
   cachedThresholdValue = null;
   cachedThresholdAt = 0;
-}
-
-function senderIsAdminFromMessage(message) {
-  const sender = message?.sender;
-  if (!sender) return false;
-  if (sender.isAdmin === true || sender.isSuperAdmin === true) return true;
-  if (typeof sender.admin === 'string') {
-    const lowered = sender.admin.toLowerCase();
-    if (lowered.includes('admin')) return true;
-  }
-  if (Array.isArray(sender.labels)) {
-    return sender.labels.some(label => typeof label === 'string' && label.toLowerCase().includes('admin'));
-  }
-  return false;
 }
 
 async function senderIsAdminInGroup(groupId, userId) {

--- a/utils/adminUtils.js
+++ b/utils/adminUtils.js
@@ -25,6 +25,30 @@ function getEnvAdminSet() {
     .filter(Boolean));
 }
 
+/**
+ * Determine if the sender metadata on a message indicates admin privileges.
+ * @param {object} message - Message object containing sender metadata
+ * @returns {boolean} True if the sender appears to be an admin
+ */
+function senderIsAdminFromMessage(message) {
+  const sender = message?.sender;
+  if (!sender) return false;
+
+  if (sender.isAdmin === true || sender.isSuperAdmin === true) return true;
+
+  if (typeof sender.admin === 'string') {
+    const lowered = sender.admin.toLowerCase();
+    if (lowered.includes('admin')) return true;
+  }
+
+  if (Array.isArray(sender.labels)) {
+    return sender.labels.some(label => typeof label === 'string' && label.toLowerCase().includes('admin'));
+  }
+
+  return false;
+}
+
 module.exports = {
-  getEnvAdminSet
+  getEnvAdminSet,
+  senderIsAdminFromMessage
 };


### PR DESCRIPTION
## Summary
- add a reusable helper in admin utils to detect admin senders from message metadata
- update the delete and ban handlers to rely on the shared helper and remove duplicated logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913406e19248332a4f8a0fd62df2d5c)