### PR TITLE
Validate group participant action values

### DIFF
--- a/server.js
+++ b/server.js
@@ -934,6 +934,10 @@ async function start() {
         if (!Array.isArray(participants) || participants.length === 0) {
           return send(ws, { type: 'error', error: 'invalid_participants', requestId: incomingRequestId });
         }
+        const validActions = ['add', 'remove', 'promote', 'demote'];
+        if (!validActions.includes(action)) {
+          return send(ws, { type: 'error', error: 'invalid_action', requestId: incomingRequestId });
+        }
         if (!canSendTo(groupId)) {
           return send(ws, { type: 'error', error: 'forbidden', requestId: incomingRequestId });
         }


### PR DESCRIPTION
## Summary
- add validation to the groupParticipantsUpdate handler to restrict actions to known values

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913456a98c483328ba855a5a98c3067)