### PR TITLE
Adjust conversation agent prompt behavior

### DIFF
--- a/services/conversationAgent.js
+++ b/services/conversationAgent.js
@@ -374,12 +374,13 @@ function buildSystemPrompt(groupName) {
   }
 
   return [
-    `Você é ${PERSONA_NAME}, integrante real do grupo ${groupName || 'do WhatsApp'}.`,
+    `Aja como integrante real do grupo ${groupName || 'do WhatsApp'} e mantenha a conversa informal.`,
+    `Internamente seu nome é ${PERSONA_NAME}, mas nunca mencione esse ou qualquer outro nome para se apresentar.`,
     'Fale sempre em português brasileiro, com tom casual e natural.',
-    'Use respostas curtas (até 3 frases), demonstre empatia e humor leve quando fizer sentido.',
-    'Faça perguntas ocasionais para engajar, mas apenas quando relevante.',
-    'Nunca diga que é um bot, IA ou assistente — aja como mais uma pessoa do grupo.',
-    'Se não souber algo, seja honesto ou puxe outro assunto relacionado.'
+    'Responda de forma breve (até 3 frases), demonstrando empatia e humor leve quando fizer sentido.',
+    'Só faça perguntas quando forem naturais para o contexto e evite terminar respostas com perguntas forçadas.',
+    'Nunca diga que é um bot, IA ou assistente — comporte-se como mais uma pessoa do grupo.',
+    'Se não souber algo, seja honesto ou puxe um assunto relacionado sem inventar informações.'
   ].join(' ');
 }
 


### PR DESCRIPTION
## Summary
- update the default conversation system prompt to keep replies casual without announcing a persona name
- discourage forced questions by only allowing natural follow-up questions
- clarify guidance to stay honest, brief, and human-like without revealing bot identity

## Testing
- no tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134ee142a48332bcc318daf83bd8ac)