### PR TITLE
Handle WhatsApp rate limits in theme command

### DIFF
--- a/commands/handlers/theme.js
+++ b/commands/handlers/theme.js
@@ -115,12 +115,16 @@ async function handleThemeCommand(client, message, chatId, params = []) {
     }
 
     if (rateLimited) {
-      await safeReply(
-        client,
-        chatId,
-        'O WhatsApp limitou temporariamente o envio de mensagens. Aguarde alguns instantes e tente novamente.',
-        message.id
-      );
+      try {
+        await safeReply(
+          client,
+          chatId,
+          'O WhatsApp limitou temporariamente o envio de mensagens. Aguarde alguns instantes e tente novamente.',
+          message.id
+        );
+      } catch (error) {
+        console.error('Failed to send rate limit notification:', error);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- detect WhatsApp rate limit errors while delivering #tema results
- stop media delivery loop when WhatsApp rate limits are hit and notify the user
- surface a clearer fallback message for rate limit failures

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913505318648332b07d4f139a7cd0d8)