### PR TITLE
Document OpenAI retry environment variables in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ MEME_IMAGE_QUALITY=low
 # Optional transcription language (ISO code)
 # MEME_TRANSCRIPTION_LANGUAGE=pt
 
+# Retry behavior for OpenAI API requests
+# OPENAI_MAX_RETRIES=2
+# OPENAI_RETRY_DELAY_MS=1000
+
 # ===== NSFW MODERATION (OPTIONAL) =====
 
 # Use external providers for stricter NSFW detection (supports comma-separated list: huggingface,openai)


### PR DESCRIPTION
## Summary
- document the optional OPENAI_MAX_RETRIES and OPENAI_RETRY_DELAY_MS settings in `.env.example`
- explain that the variables control retry behavior for OpenAI API requests

## Testing
- not run; documentation-only change

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138e74d0908332915b035632b51b60)