### PR TITLE
Fix retry attempt counter denominator

### DIFF
--- a/services/ai.js
+++ b/services/ai.js
@@ -90,7 +90,7 @@ async function executeWithAiRetry(action, {
       attempt += 1;
       const backoffMs = baseDelayMs * attempt;
       console.warn(
-        `[AI] ${actionLabel} falhou (tentativa ${attempt}/${maxRetries + 1}): ${error?.message || error}`
+        `[AI] ${actionLabel} falhou (tentativa ${attempt}/${maxRetries}): ${error?.message || error}`
       );
       await sleep(backoffMs);
     }


### PR DESCRIPTION
## Summary
- adjust retry logging to show attempt count using maxRetries instead of maxRetries + 1

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138fb306e083328250975b91a4be2c)