### PR TITLE
Fix #ban mention detection for LID users

### DIFF
--- a/tests/unit/banCommand.test.js
+++ b/tests/unit/banCommand.test.js
@@ -276,13 +276,38 @@ const tests = [
     name: 'extractMentionedJid returns null when no mention',
     fn: async () => {
       const { extractMentionedJid } = loadBanHandler();
-      
+
       const message = {
         body: '#ban'
       };
-      
+
       const result = extractMentionedJid(message);
       assertEqual(result, null, 'Should return null when no mention');
+    }
+  },
+
+  {
+    name: 'extractMentionedJid handles contextInfo mentions from LID users',
+    fn: async () => {
+      const { extractMentionedJid } = loadBanHandler();
+
+      const message = {
+        body: '#ban @user',
+        contextInfo: {
+          mentionedJid: ['20018943291402@LID'],
+          participant: '20018943291402@LID'
+        },
+        message: {
+          extendedTextMessage: {
+            contextInfo: {
+              mentionedJid: ['20018943291402:12@LID']
+            }
+          }
+        }
+      };
+
+      const result = extractMentionedJid(message);
+      assertEqual(result, '20018943291402:12@lid', 'Should normalize and return first valid mentioned JID');
     }
   }
 ];


### PR DESCRIPTION
## Summary
- expand the #ban mention extractor to inspect additional contextInfo sources and normalize mentions
- prefer device-specific LID identifiers when available so bans resolve the correct participant
- cover the new extraction logic with a unit test that simulates LID mentions

## Testing
- npm test -- ban

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691396975dec83329a8c348c73ad116b)