### PR TITLE
feat(runtime): add conversation health metrics and AI timeout

### DIFF
--- a/src/services/ai.js
+++ b/src/services/ai.js
@@ -7,12 +7,15 @@ const { spawn } = require('child_process');
 const { resolveFfmpegPath } = require('../utils/ffmpeg');
 const ffmpegPath = resolveFfmpegPath();
 const { TEMP_DIR } = require('../paths');
+const { conversationMetrics } = require('./conversationMetrics');
 
-function createOpenAIClient({ apiKey, baseURL }) {
+function createOpenAIClient({ apiKey, baseURL, timeoutMs = 0 }) {
   if (!apiKey) return null;
   const options = { apiKey };
   const backfillTimeout = Number(process.env.BACKFILL_OPENAI_TIMEOUT_MS || 0);
-  if (Number.isFinite(backfillTimeout) && backfillTimeout > 0) options.timeout = backfillTimeout;
+  const configuredTimeout = Number(timeoutMs || 0);
+  const effectiveTimeout = backfillTimeout > 0 ? backfillTimeout : configuredTimeout;
+  if (Number.isFinite(effectiveTimeout) && effectiveTimeout > 0) options.timeout = effectiveTimeout;
   if (baseURL) options.baseURL = baseURL;
   return new OpenAI(options);
 }
@@ -21,7 +24,8 @@ const multimodalApiKey = process.env.OPENAI_MULTIMODAL_API_KEY || process.env.LE
 const multimodalBaseURL = process.env.OPENAI_MULTIMODAL_BASE_URL || '';
 let openai = createOpenAIClient({
   apiKey: multimodalApiKey,
-  baseURL: multimodalBaseURL
+  baseURL: multimodalBaseURL,
+  timeoutMs: Number(process.env.MULTIMODAL_AI_TIMEOUT_MS || 90000)
 });
 
 if (!openai) {
@@ -113,17 +117,24 @@ function shouldRetryOpenAiError(error) {
 async function executeWithAiRetry(action, {
   actionLabel = 'OpenAI request',
   maxRetries = DEFAULT_MAX_RETRIES,
-  baseDelayMs = DEFAULT_RETRY_DELAY_MS
+  baseDelayMs = DEFAULT_RETRY_DELAY_MS,
+  metricStage = null
 } = {}) {
   let attempt = 0;
 
   while (true) {
+    const finishMetric = metricStage ? conversationMetrics.start(metricStage) : null;
     try {
-      return await action();
+      const result = await action();
+      if (finishMetric) finishMetric('success', { attempt: attempt + 1 });
+      return result;
     } catch (error) {
-      if (!shouldRetryOpenAiError(error) || attempt >= maxRetries) {
-        throw error;
+      const isRetryable = shouldRetryOpenAiError(error) && attempt < maxRetries;
+      if (finishMetric) {
+        const status = inferReasonCodeFromError(error) === 'timeout' ? 'timeout' : 'error';
+        finishMetric(status, { attempt: attempt + 1, retryable: isRetryable });
       }
+      if (!isRetryable) throw error;
 
       attempt += 1;
       const backoffMs = baseDelayMs * attempt;
@@ -855,7 +866,7 @@ async function generateConversationalReply({
           stop: ['\nUsuário:', '\nUser:', '\nSistema:', '\nSystem:'],
           signal
         }),
-        { actionLabel: `resposta conversacional (${label})` }
+        { actionLabel: `resposta conversacional (${label})`, metricStage: 'ai_safe_fallback' }
       );
 
       const text = await finalizeConversationalOutput({
@@ -890,7 +901,7 @@ async function generateConversationalReply({
           chat_template_kwargs: { enable_thinking: false },
           signal
         }),
-        { actionLabel: 'resposta conversacional (fallback OpenAI)' }
+        { actionLabel: 'resposta conversacional (fallback OpenAI)', metricStage: 'ai_cloud_fallback' }
       );
 
       const choice = await finalizeConversationalOutput({
@@ -939,7 +950,7 @@ async function generateConversationalReply({
         chat_template_kwargs: { enable_thinking: false },
         signal
       }),
-      { actionLabel: 'resposta conversacional' }
+      { actionLabel: 'resposta conversacional', metricStage: 'ai_primary' }
     );
 
     let choiceRaw = response?.choices?.[0]?.message?.content || '';
@@ -958,7 +969,7 @@ async function generateConversationalReply({
             chat_template_kwargs: { enable_thinking: false },
             signal
           }),
-          { actionLabel: 'resposta conversacional (retry por truncamento)' }
+          { actionLabel: 'resposta conversacional (retry por truncamento)', metricStage: 'ai_retry_truncation' }
         );
         choiceRaw = response?.choices?.[0]?.message?.content || choiceRaw;
       } catch (retryErr) {
@@ -990,7 +1001,7 @@ async function generateConversationalReply({
             chat_template_kwargs: { enable_thinking: false },
             signal
           }),
-          { actionLabel: 'resposta conversacional (retry por final abrupto)' }
+          { actionLabel: 'resposta conversacional (retry por final abrupto)', metricStage: 'ai_retry_abrupt_tail' }
         );
 
         const continuityChoice = await finalizeConversationalOutput({
@@ -1033,7 +1044,7 @@ async function generateConversationalReply({
           stop: ['\nUsuário:', '\nUser:', '\nSistema:', '\nSystem:'],
           signal
         }),
-        { actionLabel: 'resposta conversacional (fallback de exceção completions)' }
+        { actionLabel: 'resposta conversacional (fallback de exceção completions)', metricStage: 'ai_exception_fallback' }
       );
 
       const text = await finalizeConversationalOutput({

--- a/src/services/conversationAgent.js
+++ b/src/services/conversationAgent.js
@@ -7,6 +7,7 @@ const { getLogCollector } = require('../utils/logCollector');
 const memory = require('../client/memory-client');
 const { CONVERSATIONS_DIR } = require('../paths');
 const { ConversationRuntime, toPositiveNumber } = require('./conversationRuntime');
+const { conversationMetrics } = require('./conversationMetrics');
 
 const ENABLED = (process.env.CONVERSATION_AGENT_ENABLED || '1').toLowerCase() !== '0' &&
   (process.env.CONVERSATION_AGENT_ENABLED || '1').toLowerCase() !== 'false';
@@ -1146,10 +1147,17 @@ async function handleGroupChatMessage(client, message, context = {}) {
             .filter(Boolean)
             .join(' ')
             .slice(-1200);
-          memoryContext = await memory.buildContext(request.chatId, [request.senderId], {
-            senderId: request.senderId,
-            query: memoryQuery
-          });
+          const finishMemoryMetric = conversationMetrics.start('memory_build_context');
+          try {
+            memoryContext = await memory.buildContext(request.chatId, [request.senderId], {
+              senderId: request.senderId,
+              query: memoryQuery
+            });
+            finishMemoryMetric('success');
+          } catch (memoryError) {
+            finishMemoryMetric(memoryError?.message?.toLowerCase().includes('timeout') ? 'timeout' : 'error');
+            throw memoryError;
+          }
         } catch (err) {
           console.warn('[ConversationAgent] Falha ao montar contexto de memória:', err?.message || err);
         }
@@ -1176,12 +1184,19 @@ async function handleGroupChatMessage(client, message, context = {}) {
         const sanitized = sanitizeReplyText(reply || '');
         if (!sanitized) return false;
 
-        if (typeof request.client.sendText === 'function') {
-          await request.client.sendText(request.chatId, sanitized);
-        } else if (typeof request.client.sendMessage === 'function') {
-          await request.client.sendMessage(request.chatId, sanitized);
-        } else {
-          await safeReply(request.client, request.chatId, sanitized);
+        const finishSendMetric = conversationMetrics.start('send_text');
+        try {
+          if (typeof request.client.sendText === 'function') {
+            await request.client.sendText(request.chatId, sanitized);
+          } else if (typeof request.client.sendMessage === 'function') {
+            await request.client.sendMessage(request.chatId, sanitized);
+          } else {
+            await safeReply(request.client, request.chatId, sanitized);
+          }
+          finishSendMetric('success');
+        } catch (sendError) {
+          finishSendMetric(sendError?.message?.toLowerCase().includes('timeout') ? 'timeout' : 'error');
+          throw sendError;
         }
 
         // Never let an answer that raced with a newer message overwrite its state.
@@ -1209,5 +1224,6 @@ async function handleGroupChatMessage(client, message, context = {}) {
 module.exports = {
   handleGroupChatMessage,
   buildContextualDirective,
-  buildSystemPrompt
+  buildSystemPrompt,
+  getConversationHealth: () => conversationMetrics.snapshot()
 };

--- a/src/services/conversationMetrics.js
+++ b/src/services/conversationMetrics.js
@@ -1,0 +1,111 @@
+const fs = require('fs');
+const path = require('path');
+
+const MAX_SAMPLES = 200;
+const metricsPath = process.env.CONVERSATION_METRICS_PATH
+  || path.join(process.cwd(), 'storage/data/memory/conversation-health.json');
+
+function percentile(values, p) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return Math.round(sorted[index]);
+}
+
+class ConversationMetrics {
+  constructor() {
+    this.startedAt = Date.now();
+    this.sequence = 0;
+    this.inFlight = new Map();
+    this.stages = new Map();
+    this.runtimeTimeoutMs = Number(process.env.CONVERSATION_RESPONSE_TIMEOUT_MS) || 12000;
+  }
+
+  start(stage, metadata = {}) {
+    const id = ++this.sequence;
+    const startedAt = process.hrtime.bigint();
+    this.inFlight.set(id, { stage, startedAt });
+    return (status = 'success', extra = {}) => this.finish(id, status, extra, metadata);
+  }
+
+  finish(id, status = 'success', extra = {}, metadata = {}) {
+    const active = this.inFlight.get(id);
+    if (!active) return null;
+    this.inFlight.delete(id);
+    const durationMs = Number(process.hrtime.bigint() - active.startedAt) / 1e6;
+    const stage = active.stage;
+    const entry = this.stages.get(stage) || { count: 0, success: 0, error: 0, timeout: 0, samples_ms: [] };
+    entry.count += 1;
+    if (status === 'success') entry.success += 1;
+    else if (status === 'timeout') entry.timeout += 1;
+    else entry.error += 1;
+    entry.samples_ms.push(Math.round(durationMs));
+    if (entry.samples_ms.length > MAX_SAMPLES) entry.samples_ms.shift();
+    this.stages.set(stage, entry);
+
+    const event = {
+      type: 'conversation_stage',
+      stage,
+      status,
+      duration_ms: Math.round(durationMs),
+      ...(metadata.request_id ? { request_id: metadata.request_id } : {}),
+      ...extra
+    };
+    console.info(`[ConversationHealth] ${JSON.stringify(event)}`);
+    this.persist();
+    return durationMs;
+  }
+
+  setRuntimeTimeout(timeoutMs) {
+    if (Number.isFinite(Number(timeoutMs)) && Number(timeoutMs) > 0) {
+      this.runtimeTimeoutMs = Number(timeoutMs);
+    }
+  }
+
+  snapshot() {
+    const stages = {};
+    for (const [stage, entry] of this.stages.entries()) {
+      const samples = entry.samples_ms;
+      stages[stage] = {
+        count: entry.count,
+        success: entry.success,
+        error: entry.error,
+        timeout: entry.timeout,
+        last_ms: samples.length ? samples[samples.length - 1] : null,
+        p50_ms: percentile(samples, 50),
+        p95_ms: percentile(samples, 95),
+        max_ms: samples.length ? Math.max(...samples) : null
+      };
+    }
+    return {
+      schema: 1,
+      generated_at: new Date().toISOString(),
+      started_at: new Date(this.startedAt).toISOString(),
+      runtime_timeout_ms: this.runtimeTimeoutMs,
+      in_flight: this.inFlight.size,
+      stages
+    };
+  }
+
+  persist() {
+    try {
+      fs.mkdirSync(path.dirname(metricsPath), { recursive: true });
+      const tmp = `${metricsPath}.tmp-${process.pid}`;
+      fs.writeFileSync(tmp, `${JSON.stringify(this.snapshot())}\n`, { mode: 0o640 });
+      fs.renameSync(tmp, metricsPath);
+    } catch (error) {
+      console.warn(`[ConversationHealth] snapshot_persist_failed ${error?.message || error}`);
+    }
+  }
+
+  reset() {
+    this.startedAt = Date.now();
+    this.inFlight.clear();
+    this.stages.clear();
+    this.persist();
+  }
+}
+
+const conversationMetrics = new ConversationMetrics();
+
+module.exports = { ConversationMetrics, conversationMetrics, metricsPath };

--- a/src/services/conversationRuntime.js
+++ b/src/services/conversationRuntime.js
@@ -1,5 +1,6 @@
 const DEFAULT_DEBOUNCE_MS = 0;
 const DEFAULT_TIMEOUT_MS = 12000;
+const { conversationMetrics } = require('./conversationMetrics');
 
 function toPositiveNumber(value, fallback, minimum = 0) {
   const parsed = Number(value);
@@ -11,6 +12,7 @@ class ConversationRuntime {
   constructor({ debounceMs = DEFAULT_DEBOUNCE_MS, timeoutMs = DEFAULT_TIMEOUT_MS, logger = console } = {}) {
     this.debounceMs = toPositiveNumber(debounceMs, DEFAULT_DEBOUNCE_MS);
     this.timeoutMs = toPositiveNumber(timeoutMs, DEFAULT_TIMEOUT_MS, 1);
+    conversationMetrics.setRuntimeTimeout(this.timeoutMs);
     this.logger = logger;
     this.entries = new Map();
   }
@@ -46,6 +48,7 @@ class ConversationRuntime {
 
       entry.active = true;
       const startedAt = Date.now();
+      const finishRuntimeMetric = conversationMetrics.start('runtime_total');
       const controller = new AbortController();
       let timeoutHandle;
       const guard = {
@@ -67,8 +70,10 @@ class ConversationRuntime {
             }, this.timeoutMs);
           })
         ]);
+        finishRuntimeMetric('success');
         this._resolveWaiter(entry, true);
       } catch (err) {
+        finishRuntimeMetric(err?.message === 'conversation_response_timeout' ? 'timeout' : 'error');
         this.logger.warn(`[ConversationRuntime] run failed key=${key} reason=${err?.message || err}`);
         this._resolveWaiter(entry, false);
       } finally {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -37,6 +37,7 @@ const { tests: messageHistoryRecoveryTests } = require('./unit/messageHistoryRec
 const { tests: mediaDownloadRetryTests } = require('./unit/mediaDownloadRetry.test');
 const { tests: schedulerTests } = require('./unit/scheduler.test');
 const { tests: conversationRuntimeTests } = require('./unit/conversationRuntime.test');
+const { tests: conversationMetricsTests } = require('./unit/conversationMetrics.test');
 const { tests: openvikingSemanticRecallTests } = require('./unit/openvikingSemanticRecall.test');
 const { tests: stickerDeliveryPolicyTests } = require('./unit/stickerDeliveryPolicy.test');
 const { tests: recentIncidentTests } = require('./unit/recentIncidents.test');
@@ -83,6 +84,7 @@ async function runAllTests() {
     results.push(await runTestSuite('Media Download Retry Tests', mediaDownloadRetryTests));
     results.push(await runTestSuite('Scheduler Tests', schedulerTests));
     results.push(await runTestSuite('Conversation Runtime Tests', conversationRuntimeTests));
+    results.push(await runTestSuite('Conversation Metrics Tests', conversationMetricsTests));
     results.push(await runTestSuite('OpenViking Semantic Recall Tests', openvikingSemanticRecallTests));
     results.push(await runTestSuite('Sticker Delivery Policy Tests', stickerDeliveryPolicyTests));
     results.push(await runTestSuite('Recent Incident Regression Tests', recentIncidentTests));

--- a/tests/unit/conversationMetrics.test.js
+++ b/tests/unit/conversationMetrics.test.js
@@ -1,0 +1,13 @@
+const { ConversationMetrics } = require('../../src/services/conversationMetrics');
+function assert(condition, message) { if (!condition) throw new Error(`Assertion failed: ${message}`); }
+const tests = [{ name: 'records separate stage health and percentiles', fn: async () => {
+  const metrics = new ConversationMetrics();
+  metrics.start('ai_primary')('success');
+  metrics.start('runtime_total')('timeout');
+  const snapshot = metrics.snapshot();
+  assert(snapshot.stages.ai_primary.count === 1, 'primary count');
+  assert(snapshot.stages.ai_primary.success === 1, 'primary success');
+  assert(snapshot.stages.runtime_total.timeout === 1, 'runtime timeout');
+  assert(snapshot.stages.runtime_total.p95_ms >= 0, 'runtime percentile');
+}}];
+module.exports = { tests };


### PR DESCRIPTION
## Summary\n- record per-stage ConversationRuntime health metrics with p50/p95/max snapshots\n- instrument memory, model attempts, retries, fallbacks, sends, and total runtime\n- add a bounded 90s timeout for multimodal AI requests so media processing reaches its fallback instead of hanging indefinitely\n\n## Validation\n- node --check\n- ESLint on changed files\n- git diff --check\n- clean worktree unit suite: 206/206\n- production-like timeout canary returned the sanitized image fallback\n\n## Rollout\nMerge and CI approval are required before restarting Bot-Client.